### PR TITLE
Add support for elquery-innertext

### DIFF
--- a/README.org
+++ b/README.org
@@ -46,6 +46,7 @@ It's like jQuery, but way less useful. Given this example HTML file,
 - ~(elq-siblings NODE)~ - Return a list of the siblings of NODE
 - ~(elq-next-children NODE)~ - Return a list of children of NODE with the
   children's children removed.
+- ~(elq-innertext NODE)~ - Return all Text from a NODE and its children
 *** Common Trait Selection
 - ~(elq-class? NODE CLASS)~ - Return whether NODE has the class CLASS
 - ~(elq-id NODE)~ - Return the id of NODE

--- a/elquery.el
+++ b/elquery.el
@@ -210,6 +210,23 @@ If there are multiple text nodes in NODE
 these text nodes"
   (plist-get node :text))
 
+(defun elquery-innertext (node)
+  "Return the text content of node and it's children.
+This function will recurse down the tree given by NODE
+and find and concatenate all :text property values."
+  (let ((children-list (elquery-children node))
+        (result-string ""))
+    (if children-list
+        (while children-list
+          (if (elquery-children (car children-list))
+              (setq result-string (concat result-string " " (elquery-innertext (car children-list))))
+            (setq result-string (concat result-string " " (plist-get (car children-list) ':text))) )
+          (setq children-list (cdr children-list))))
+    (let ((string-length (length result-string)))
+      (if (> string-length 1)
+          (substring result-string 1 (length result-string))
+        "")) ))
+
 (defun elquery-classes (node)
   "Return a list of NODE's classes."
   (let ((classes (elquery-prop node :class)))

--- a/test/elquery-test.el
+++ b/test/elquery-test.el
@@ -29,5 +29,13 @@
                    (elquery-fmt (car (elquery-$ ".form-section" tree)))))
     (should (equal "<script>" (elquery-fmt (car (elquery-$ "script" tree)))))))
 
+(ert-deftest elquery--innertext-test ()
+  (let ((tree (elquery-read-file "test/test.html")))
+
+    (should (equal "Hello World! ExtraCode Special P"
+                   (elquery-innertext (car (elquery-$ ".multiline-section .e" (elquery-read-string document-content))))))
+    (should (equal "ExtraCode Special P"
+                   (elquery-innertext (car (elquery-$ ".multiline-section .d" (elquery-read-string document-content))))))))
+
 (provide 'elquery-test)
 ;;; elquery-test.el ends here

--- a/test/test.html
+++ b/test/test.html
@@ -17,5 +17,11 @@
         <button id="color-submit-button" type="submit">Submit</button>
       </form>
     </section>
+    <section class="multiline-section">
+      <p class='e'>
+        Hello World!
+        <code>ExtraCode <p class='d'> Special P</p></code>
+      </p>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
A recursive function to retrieve all text out of a given node and its children.

This is akin to [`Node.innerText`](https://developer.mozilla.org/de/docs/Web/API/Node/innerText) in the specification for the HTML living standard.